### PR TITLE
core: perform channelz obj removal before things that may throw (#4235)

### DIFF
--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -560,6 +560,7 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
         log.log(Level.FINE, "[{0}] {1} for {2} is terminated",
             new Object[] {logId, transport.getLogId(), address});
       }
+      channelz.removeClientSocket(transport);
       handleTransportInUseState(transport, false);
       try {
         synchronized (lock) {
@@ -574,7 +575,6 @@ final class InternalSubchannel implements Instrumented<ChannelStats> {
       } finally {
         channelExecutor.drain();
       }
-      channelz.removeClientSocket(transport);
       Preconditions.checkState(activeTransport != transport,
           "activeTransport still points to this transport. "
           + "Seems transportShutdown() was not called.");

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -799,12 +799,12 @@ final class ManagedChannelImpl extends ManagedChannel implements Instrumented<Ch
     }
     if (shutdown.get() && subchannels.isEmpty() && oobChannels.isEmpty()) {
       logger.log(Level.FINE, "[{0}] Terminated", getLogId());
+      channelz.removeRootChannel(this);
       terminated = true;
       terminatedLatch.countDown();
       executorPool.returnObject(executor);
       // Release the transport factory so that it can deallocate any resources.
       transportFactory.close();
-      channelz.removeRootChannel(this);
     }
   }
 

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -240,10 +240,10 @@ final class OobChannel extends ManagedChannel implements Instrumented<ChannelSta
 
   // must be run from channel executor
   void handleSubchannelTerminated() {
+    channelz.removeSubchannel(this);
     // When delayedTransport is terminated, it shuts down subchannel.  Therefore, at this point
     // both delayedTransport and subchannel have terminated.
     executorPool.returnObject(executor);
-    channelz.removeSubchannel(this);
     terminatedLatch.countDown();
   }
 

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -294,10 +294,10 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
    */
   private void transportClosed(ServerTransport transport) {
     synchronized (lock) {
-      channelz.removeServerSocket(ServerImpl.this, transport);
       if (!transports.remove(transport)) {
         throw new AssertionError("Transport already removed");
       }
+      channelz.removeServerSocket(ServerImpl.this, transport);
       checkForTermination();
     }
   }
@@ -310,12 +310,12 @@ public final class ServerImpl extends io.grpc.Server implements Instrumented<Ser
           throw new AssertionError("Server already terminated");
         }
         terminated = true;
+        channelz.removeServer(this);
         if (executor != null) {
           executor = executorPool.returnObject(executor);
         }
         // TODO(carl-mastrangelo): move this outside the synchronized block.
         lock.notifyAll();
-        channelz.removeServer(this);
       }
     }
   }


### PR DESCRIPTION
This way we won't risk an exception making us fail to clean up.
For transportClosed only remove if we know this isn't a
duplicate call to close.